### PR TITLE
:recycle: oauthに関するコードをutilsからmodel層へ移行 #8

### DIFF
--- a/internal/controller/oauth.go
+++ b/internal/controller/oauth.go
@@ -7,7 +7,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 
-	"github.com/shwatanap/gotion/internal/utils/oauth"
+	"github.com/shwatanap/gotion/internal/model"
 )
 
 const OAUTH_STATE = "oauth-state"
@@ -17,8 +17,8 @@ func GoogleSignUp(c *gin.Context) {
 	oauthState := id.String()
 	// TODO: 本番環境と開発環境でドメインを変える
 	c.SetCookie(OAUTH_STATE, oauthState, 365*24*60, "/oauth/google", "localhost", true, true)
-	g, _ := oauth.NewGoogle()
-	c.Redirect(http.StatusFound, g.GetAuthCodeURL(oauthState))
+	o, _ := model.NewOAuth()
+	c.Redirect(http.StatusFound, o.GetAuthCodeURL(oauthState))
 }
 
 func GoogleSignUpCallback(c *gin.Context) {

--- a/internal/model/oauth.go
+++ b/internal/model/oauth.go
@@ -1,4 +1,4 @@
-package oauth
+package model
 
 import (
 	"context"
@@ -11,15 +11,11 @@ import (
 	"google.golang.org/api/calendar/v3"
 )
 
-type Google struct {
+type OAuth struct {
 	Config *oauth2.Config
 }
 
-func NewGoogle() (*Google, error) {
-	return newGoogle()
-}
-
-func newGoogle() (*Google, error) {
+func NewOAuth() (*OAuth, error) {
 	b, err := os.ReadFile("credentials_web.json")
 	if err != nil {
 		return nil, fmt.Errorf("nable to read client secret file: %v", err)
@@ -28,19 +24,19 @@ func newGoogle() (*Google, error) {
 	if err != nil {
 		return nil, fmt.Errorf("nable to parse client secret file to config: %v", err)
 	}
-	google := &Google{
+	oauth := &OAuth{
 		Config: config,
 	}
-	return google, nil
+	return oauth, nil
 }
 
-func (g *Google) GetAuthCodeURL(oauthState string) string {
+func (g *OAuth) GetAuthCodeURL(oauthState string) string {
 	// TODO: stateをどうするか
 	authURL := g.Config.AuthCodeURL(oauthState, oauth2.AccessTypeOffline)
 	return authURL
 }
 
-func (g *Google) GetClient(authCode string) (*http.Client, error) {
+func (g *OAuth) GetClient(authCode string) (*http.Client, error) {
 	token, err := g.Config.Exchange(context.TODO(), authCode)
 	if err != nil {
 		return nil, fmt.Errorf("unable to retrieve token from web: %v", err)


### PR DESCRIPTION
# issue
https://github.com/shwatanap/gotion/issues/8

# 変更点
-  oauthに関するコードをutilsからmodel層へ移行
- model名をgoogleからoauthに変更